### PR TITLE
Cluster links unidirectional unauthenticated

### DIFF
--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -377,6 +377,7 @@ type InstanceServer interface {
 	GetClusterLinkNames() (clusterLinkNames []string, err error)
 	GetClusterLinks() (clusterLinks []api.ClusterLink, err error)
 	GetClusterLinkState(name string) (clusterLinkState *api.ClusterLinkState, ETag string, err error)
+	GetClusterLinkCertificate(address string) (fingerprint string, pemCert string, err error)
 	CreateClusterLink(clusterLink api.ClusterLinksPost) (err error)
 	CreateIdentityClusterLinkToken(clusterLink api.ClusterLinksPost) (certificateAddToken *api.CertificateAddToken, err error)
 	UpdateClusterLink(name string, clusterLink api.ClusterLinkPut, ETag string) (err error)

--- a/client/lxd_cluster.go
+++ b/client/lxd_cluster.go
@@ -437,6 +437,25 @@ func (r *ProtocolLXD) CreateIdentityClusterLinkToken(clusterLink api.ClusterLink
 	return &token, nil
 }
 
+// GetClusterLinkCertificate fetches the TLS certificate from the given address via the server.
+// It returns the certificate fingerprint and PEM-encoded certificate for user verification.
+func (r *ProtocolLXD) GetClusterLinkCertificate(address string) (fingerprint string, certificate string, err error) {
+	err = r.CheckExtension("cluster_links_unidirectional")
+	if err != nil {
+		return "", "", err
+	}
+
+	var resp api.ClusterLinkCertificate
+	_, err = r.queryStruct(http.MethodGet,
+		api.NewURL().Path("cluster", "links", "certificate").WithQuery("address", address).String(),
+		nil, "", &resp)
+	if err != nil {
+		return "", "", err
+	}
+
+	return resp.Fingerprint, resp.Certificate, nil
+}
+
 // UpdateClusterLink updates a cluster link.
 func (r *ProtocolLXD) UpdateClusterLink(name string, clusterLink api.ClusterLinkPut, ETag string) error {
 	err := r.CheckExtension("cluster_links")

--- a/doc/explanation/clusters.md
+++ b/doc/explanation/clusters.md
@@ -160,17 +160,20 @@ See {ref}`howto-cluster-groups` and {ref}`cluster-target-instance` for more info
 
 Cluster links enable secure communication between separate LXD clusters by pinning the remote cluster's TLS certificate and optionally establishing mutual trust.
 
-Cluster links are the foundation for {ref}`replicators <exp-replicators>`, which use bidirectional links to sync instances across clusters for active-passive disaster recovery. Unidirectional links are suited to scenarios where one cluster needs to read from another without granting reciprocal access.
+Cluster links are the foundation for {ref}`replicators <exp-replicators>`, which use bidirectional links to sync instances across clusters for active-passive disaster recovery. Unidirectional links are suited to scenarios where one cluster needs to read from another without granting reciprocal access, or for anonymous access to a cluster that exposes resources publicly.
 
 ### Link types
 
-There are two link types, each suited to different trust and access requirements:
+There are three link types, each suited to different trust and access requirements:
 
 `bidirectional`
 : Both clusters authenticate each other using mutual TLS. Each side creates an identity for the other and can initiate requests to the other. This is the default type.
 
 `unidirectional`
 : A pins B's certificate and uses a token to activate a pending identity that B created for A. B stores a corresponding link entry and can authenticate incoming requests from A, but holds no address for A and cannot initiate requests to it.
+
+`unidirectional-unauthenticated`
+: Only the initiating cluster (A) stores a link to B. A connects to B without presenting a client certificate, relying solely on certificate pinning for server authentication. B is completely unaware of the link and no identity is created on either side. Use this type when B exposes resources publicly or when you want read-only, anonymous-style access to B.
 
 ### How cluster links work
 
@@ -189,6 +192,12 @@ All link types rely on TLS certificate pinning: A fetches and pins B's certifica
 1. **Cluster A** consumes the token with `lxc cluster link create <name> --token <token> --unidirectional`, pins B's certificate, and calls back to B to activate the pending identity.
 1. A has an active link to B with no associated identity. B has an active identity for A and a corresponding link row.
 
+#### Unauthenticated unidirectional connection process
+
+1. **Cluster A** runs `lxc cluster link create <name> --unauthenticated --remote-address <addr>`.
+1. The CLI fetches B's certificate and displays the fingerprint for the user to confirm.
+1. A stores the link locally with B's pinned certificate. B is not contacted and remains unaware of the link.
+
 For more information, see: {ref}`howto-cluster-links-create`.
 
 (exp-clusters-links-identity)=
@@ -200,6 +209,7 @@ The identities created depend on the link type:
   - **Pending**: A trust token has been generated but the link has not been activated yet.
   - **Active**: Both clusters have exchanged certificates and the link is operational.
 - **Unidirectional (authenticated)**: B creates an identity for A and a corresponding link entry (no addresses, so B cannot reach A, but can manage A's access via `lxc cluster link delete`). A stores B's certificate directly without an associated identity.
+- **Unidirectional unauthenticated**: No identity is created on either side.
 
 Identities are managed using {ref}`fine-grained-authorization`.
 

--- a/doc/howto/cluster_links_create.md
+++ b/doc/howto/cluster_links_create.md
@@ -7,7 +7,7 @@ myst:
 (howto-cluster-links-create)=
 # How to create cluster links
 
-{ref}`Cluster links <exp-cluster-links>` connect separate LXD clusters. There are two link types — bidirectional and unidirectional (authenticated) — each with a different creation flow.
+{ref}`Cluster links <exp-cluster-links>` connect separate LXD clusters. There are three link types — bidirectional, unidirectional (authenticated), and unidirectional-unauthenticated — each with a different creation flow.
 
 (howto-cluster-links-auth)=
 ## Prepare authentication
@@ -123,6 +123,32 @@ Follow these steps:
    ```
 
 After these steps, Cluster A has a link with `type: unidirectional` and no associated identity. Cluster B has an active `Cluster link certificate` identity for A and a corresponding link row.
+
+(howto-cluster-links-create-unauthenticated)=
+## Create an unauthenticated unidirectional cluster link
+
+An unauthenticated unidirectional link lets Cluster A connect to Cluster B without any token exchange. A fetches and pins B's TLS certificate, but B is completely unaware of the link — no identity is created on either side. Use this type when B exposes resources publicly or when you want anonymous-style read access.
+
+No authentication groups are required for unauthenticated links.
+
+On Cluster A (the initiator), create the cluster link:
+
+```bash
+lxc cluster link create <name-for-cluster-b> --unauthenticated --remote-address <cluster-b-address>
+```
+
+This command:
+- Fetches Cluster B's TLS certificate through the LXD server.
+- Displays the certificate fingerprint for you to confirm.
+- Stores the link locally on A with B's pinned certificate.
+
+Example:
+
+```bash
+lxc cluster link create cluster_b --unauthenticated --remote-address 10.0.0.2:8443
+```
+
+After these steps, Cluster A has a link with `type: unidirectional-unauthenticated` and no associated identity. Cluster B has no link or identity for A.
 
 (howto-cluster-links-identities)=
 ## View the underlying identities

--- a/doc/howto/cluster_links_manage.md
+++ b/doc/howto/cluster_links_manage.md
@@ -177,4 +177,5 @@ The effect of deleting a cluster link varies by type:
 
 - **Bidirectional**: Deleting on one cluster removes the trust and identity only on that cluster. The other cluster retains its identity and trust until you also delete the link there. To fully disconnect, run the command on both clusters.
 - **Unidirectional (authenticated)**: Deleting on Cluster A removes only A's link row. Cluster B retains its identity and link row until B explicitly deletes its link.
+- **Unidirectional unauthenticated**: Deleting on Cluster A removes A's link row. Since B has no knowledge of the link, no further cleanup is required.
 ```

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -429,6 +429,21 @@ definitions:
         title: ClusterLink represents high-level information about a cluster link.
         type: object
         x-go-package: github.com/canonical/lxd/shared/api
+    ClusterLinkCertificate:
+        properties:
+            certificate:
+                description: PEM-encoded X.509 certificate.
+                example: '-----BEGIN CERTIFICATE-----\n...'
+                type: string
+                x-go-name: Certificate
+            fingerprint:
+                description: SHA-256 fingerprint of the certificate.
+                example: a1b2c3d4...
+                type: string
+                x-go-name: Fingerprint
+        title: ClusterLinkCertificate represents a remote cluster certificate fetched for user verification.
+        type: object
+        x-go-package: github.com/canonical/lxd/shared/api
     ClusterLinkMemberState:
         properties:
             address:
@@ -529,6 +544,11 @@ definitions:
                 example: lxd02
                 type: string
                 x-go-name: Name
+            remote_address:
+                description: RemoteAddress is the address of the remote cluster, used for unauthenticated unidirectional links.
+                example: 10.0.0.1:8443
+                type: string
+                x-go-name: RemoteAddress
             trust_token:
                 description: |-
                     TrustToken for creating a cluster link. This is included in requests to create an active cluster link on the local cluster and activate a pending cluster link on the linked cluster.
@@ -10135,6 +10155,50 @@ paths:
                 "500":
                     $ref: '#/responses/InternalServerError'
             summary: Get the cluster link state
+            tags:
+                - cluster-links
+    /1.0/cluster/links/certificate:
+        get:
+            description: |-
+                Fetches the TLS certificate from the given remote address for user verification.
+                This is used as the first step of the unauthenticated unidirectional cluster link creation flow.
+            operationId: cluster_links_certificate_get
+            parameters:
+                - description: Address of the remote cluster
+                  example: 10.0.0.1:8443
+                  in: query
+                  name: address
+                  type: string
+            produces:
+                - application/json
+            responses:
+                "200":
+                    description: Remote cluster certificate
+                    schema:
+                        description: Sync response
+                        properties:
+                            metadata:
+                                $ref: '#/definitions/ClusterLinkCertificate'
+                            status:
+                                description: Status description
+                                example: Success
+                                type: string
+                            status_code:
+                                description: Status code
+                                example: 200
+                                type: integer
+                            type:
+                                description: Response type
+                                example: sync
+                                type: string
+                        type: object
+                "400":
+                    $ref: '#/responses/BadRequest'
+                "403":
+                    $ref: '#/responses/Forbidden'
+                "500":
+                    $ref: '#/responses/InternalServerError'
+            summary: Get the remote cluster certificate
             tags:
                 - cluster-links
     /1.0/cluster/links?recursion=1:

--- a/lxc/cluster_link.go
+++ b/lxc/cluster_link.go
@@ -86,10 +86,12 @@ type cmdClusterLinkCreate struct {
 	global  *cmdGlobal
 	cluster *cmdCluster
 
-	flagToken          string
-	flagAuthGroups     []string
-	flagDescription    string
-	flagUnidirectional bool
+	flagToken           string
+	flagAuthGroups      []string
+	flagDescription     string
+	flagUnidirectional  bool
+	flagUnauthenticated bool
+	flagRemoteAddress   string
 }
 
 func (c *cmdClusterLinkCreate) command() *cobra.Command {
@@ -99,7 +101,8 @@ func (c *cmdClusterLinkCreate) command() *cobra.Command {
 	cmd.Long = cli.FormatSection("Description", `Create cluster links
 
 Bidirectional (default): run without --token on cluster A to get a token, then run with --token on cluster B.
-Unidirectional authenticated: run "lxc auth identity create cluster-link/<name>" on B to get a token, then run with --token --unidirectional on A.`)
+Unidirectional authenticated: run "lxc auth identity create cluster-link/<name>" on B to get a token, then run with --token --unidirectional on A.
+Unidirectional unauthenticated: run with --unauthenticated --remote-address on A; the certificate fingerprint is shown for confirmation before the link is created.`)
 	cmd.Example = cli.FormatSection("", `lxc cluster link create backup-cluster --auth-group backups
     Create a pending bidirectional cluster link called "backup-cluster".
 
@@ -107,11 +110,16 @@ lxc cluster link create main-cluster --token <token> --auth-group backups
     Create an active bidirectional cluster link called "main-cluster" using a token from "backup-cluster".
 
 lxc cluster link create image-host --token <token> --unidirectional
-    Create an authenticated unidirectional cluster link called "image-host" using a token issued by the remote cluster.`)
+    Create an authenticated unidirectional cluster link called "image-host" using a token issued by the remote cluster.
+
+lxc cluster link create image-host --unauthenticated --remote-address 10.0.0.1:8443
+    Create an unauthenticated unidirectional cluster link called "image-host" by pinning the remote certificate.`)
 	cmd.Flags().StringVarP(&c.flagToken, "token", "t", "", cli.FormatStringFlagLabel("Trust token to use when creating cluster link"))
 	cmd.Flags().StringSliceVarP(&c.flagAuthGroups, "auth-group", "g", []string{}, cli.FormatStringFlagLabel("Authentication groups to add the newly created cluster link identity to"))
 	cmd.Flags().StringVarP(&c.flagDescription, "description", "d", "", cli.FormatStringFlagLabel("Cluster link description"))
 	cmd.Flags().BoolVar(&c.flagUnidirectional, "unidirectional", false, cli.FormatStringFlagLabel("Create a unidirectional cluster link (requires --token)"))
+	cmd.Flags().BoolVar(&c.flagUnauthenticated, "unauthenticated", false, cli.FormatStringFlagLabel("Create a link without presenting a client certificate (requires --remote-address)"))
+	cmd.Flags().StringVar(&c.flagRemoteAddress, "remote-address", "", cli.FormatStringFlagLabel("Address of the remote cluster for unauthenticated unidirectional links"))
 
 	cmd.RunE = c.run
 
@@ -136,8 +144,8 @@ func (c *cmdClusterLinkCreate) run(cmd *cobra.Command, args []string) error {
 	}
 
 	// If stdin isn't a terminal, read text from it.
-	// If stdin isn't a terminal, read text from it.
-	if !termios.IsTerminal(getStdinFd()) {
+	// Skip this for unauthenticated unidirectional links: stdin is reserved for the interactive certificate confirmation prompt.
+	if !termios.IsTerminal(getStdinFd()) && !c.flagUnauthenticated {
 		contents, err := io.ReadAll(os.Stdin)
 		if err != nil {
 			return err
@@ -161,11 +169,23 @@ func (c *cmdClusterLinkCreate) run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	if c.flagUnidirectional && c.flagUnauthenticated {
+		return errors.New("--unidirectional and --unauthenticated cannot be used together")
+	}
+
+	if c.flagUnauthenticated && c.flagRemoteAddress == "" {
+		return errors.New("--unauthenticated requires --remote-address")
+	}
+
+	if !c.flagUnauthenticated && c.flagRemoteAddress != "" {
+		return errors.New("--remote-address requires --unauthenticated")
+	}
+
 	if c.flagUnidirectional && c.flagToken == "" {
 		return errors.New("--unidirectional requires --token")
 	}
 
-	if c.flagUnidirectional && len(c.flagAuthGroups) > 0 {
+	if (c.flagUnidirectional || c.flagUnauthenticated) && len(c.flagAuthGroups) > 0 {
 		return errors.New("--auth-group cannot be used with unidirectional cluster links")
 	}
 
@@ -195,6 +215,51 @@ func (c *cmdClusterLinkCreate) run(cmd *cobra.Command, args []string) error {
 	// Set auth groups if provided
 	if len(c.flagAuthGroups) > 0 {
 		clusterLink.AuthGroups = c.flagAuthGroups
+	}
+
+	// Unauthenticated unidirectional: fetch cert, prompt user, then create.
+	if c.flagUnauthenticated {
+		fingerprint, pemCert, err := client.GetClusterLinkCertificate(c.flagRemoteAddress)
+		if err != nil {
+			return fmt.Errorf("Failed retrieving remote certificate: %w", err)
+		}
+
+		fmt.Printf("Certificate fingerprint: %s\n", fingerprint)
+		fmt.Print("ok (y/n/[fingerprint])? ")
+		for {
+			line, err := shared.ReadStdin()
+			if err != nil {
+				return err
+			}
+
+			if string(line) == fingerprint || (len(line) > 0 && strings.ToLower(string(line[0])) == "y") {
+				break
+			}
+
+			if len(line) == len(fingerprint) {
+				return errors.New("The provided fingerprint does not match the remote cluster certificate fingerprint")
+			}
+
+			if len(line) == 0 || strings.ToLower(string(line[0])) == "n" {
+				return errors.New("Remote cluster certificate NACKed by user")
+			}
+
+			fmt.Print("Please type 'y', 'n' or the fingerprint: ")
+		}
+
+		clusterLink.Type = api.ClusterLinkTypeUnidirectionalUnauthenticated
+		clusterLink.RemoteAddress = c.flagRemoteAddress
+		clusterLink.ClusterCertificate = pemCert
+		err = client.CreateClusterLink(clusterLink)
+		if err != nil {
+			return err
+		}
+
+		if !c.global.flagQuiet {
+			fmt.Printf("Cluster link %s created\n", clusterLinkName)
+		}
+
+		return nil
 	}
 
 	// Authenticated unidirectional: consume B's token, pin B's cert on A, activate B's identity.

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -61,6 +61,7 @@ var api10 = []APIEndpoint{
 	clusterMemberCmd,
 	clusterMemberStateCmd,
 	clusterMembersCmd,
+	clusterLinksCertificateCmd,
 	clusterLinkCmd,
 	clusterLinksCmd,
 	clusterLinkStateCmd,

--- a/lxd/api_cluster_link.go
+++ b/lxd/api_cluster_link.go
@@ -66,6 +66,13 @@ var clusterLinkStateCmd = APIEndpoint{
 	Get: APIEndpointAction{Handler: clusterLinkStateGet, AccessHandler: allowPermission(entity.TypeClusterLink, auth.EntitlementCanView, "name")},
 }
 
+var clusterLinksCertificateCmd = APIEndpoint{
+	Path:        "cluster/links/certificate",
+	MetricsType: entity.TypeClusterLink,
+
+	Get: APIEndpointAction{Handler: clusterLinkCertificateGet, AccessHandler: allowPermission(entity.TypeServer, auth.EntitlementCanCreateClusterLinks)},
+}
+
 // swagger:operation GET /1.0/cluster/links cluster-links cluster_links_get
 //
 //		Get the cluster links
@@ -705,7 +712,24 @@ func clusterLinksPost(d *Daemon, r *http.Request) response.Response {
 	notify := newIdentityNotificationFunc(s, r, networkCert, serverCert)
 	requestor := request.CreateRequestor(r.Context())
 
+	// Unauthenticated unidirectional: name + remote_address, no token or identity-related settings.
+	if req.Name != "" && req.RemoteAddress != "" && clusterLinkType == dbCluster.ClusterLinkType(api.ClusterLinkTypeUnidirectionalUnauthenticated) {
+		if req.TrustToken != "" {
+			return response.BadRequest(errors.New("Trust token cannot be set for unauthenticated unidirectional cluster links"))
+		}
+
+		if len(req.AuthGroups) > 0 {
+			return response.BadRequest(errors.New("Auth groups cannot be set for unauthenticated unidirectional cluster links"))
+		}
+
+		return clusterLinkCreateUnidirectionalUnauthenticated(s, r, req, requestor)
+	}
+
 	if req.Name != "" && req.TrustToken == "" {
+		if clusterLinkType == dbCluster.ClusterLinkType(api.ClusterLinkTypeUnidirectionalUnauthenticated) {
+			return response.BadRequest(errors.New("Unauthenticated unidirectional cluster links require remote_address and cluster_certificate"))
+		}
+
 		return clusterLinkCreatePending(s, r, req, clusterLinkType, notify, requestor)
 	}
 
@@ -1469,7 +1493,12 @@ func clusterLinkStateGet(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(fmt.Errorf("Failed loading cluster link %q: %w", name, err))
 	}
 
-	args := cluster.GetClusterLinkConnectionArgs(clusterCert, targetCert)
+	var args *lxd.ConnectionArgs
+	if clusterLink.Type == api.ClusterLinkTypeUnidirectionalUnauthenticated {
+		args = cluster.GetUnauthenticatedClusterLinkConnectionArgs(targetCert)
+	} else {
+		args = cluster.GetClusterLinkConnectionArgs(clusterCert, targetCert)
+	}
 
 	args.SkipGetServer = true
 
@@ -1652,4 +1681,135 @@ func clusterLinkCreateUnidirectionalAuthenticated(s *state.State, r *http.Reques
 	}
 
 	return response.SmartError(api.StatusErrorf(http.StatusBadGateway, "Failed activating unidirectional cluster link %q: %s", req.Name, strings.Join(errStrings, "; ")))
+}
+
+// swagger:operation GET /1.0/cluster/links/certificate cluster-links cluster_links_certificate_get
+//
+//	Get the remote cluster certificate
+//
+//	Fetches the TLS certificate from the given remote address for user verification.
+//	This is used as the first step of the unauthenticated unidirectional cluster link creation flow.
+//
+//	---
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: address
+//	    description: Address of the remote cluster
+//	    type: string
+//	    example: 10.0.0.1:8443
+//	responses:
+//	  "200":
+//	    description: Remote cluster certificate
+//	    schema:
+//	      type: object
+//	      description: Sync response
+//	      properties:
+//	        type:
+//	          type: string
+//	          description: Response type
+//	          example: sync
+//	        status:
+//	          type: string
+//	          description: Status description
+//	          example: Success
+//	        status_code:
+//	          type: integer
+//	          description: Status code
+//	          example: 200
+//	        metadata:
+//	          $ref: "#/definitions/ClusterLinkCertificate"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
+func clusterLinkCertificateGet(d *Daemon, r *http.Request) response.Response {
+	address := r.URL.Query().Get("address")
+	if address == "" {
+		return response.BadRequest(errors.New("Address query parameter is required"))
+	}
+
+	canonicalAddress := util.CanonicalNetworkAddress(address, shared.HTTPSDefaultPort)
+	cert, err := shared.GetRemoteCertificate(r.Context(), "https://"+canonicalAddress, version.UserAgent)
+	if err != nil {
+		return response.SmartError(fmt.Errorf("Failed retrieving certificate from %q: %w", address, err))
+	}
+
+	pemCert := string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw}))
+	return response.SyncResponse(true, api.ClusterLinkCertificate{
+		Fingerprint: shared.CertFingerprint(cert),
+		Certificate: pemCert,
+	})
+}
+
+// clusterLinkCreateUnidirectionalUnauthenticated handles creation of an unauthenticated unidirectional cluster link.
+// A (image client) downloads and pins B's certificate using only the remote address. No identity is created on either side.
+// The ClusterCertificate field must contain the PEM certificate for B, already confirmed by the caller.
+func clusterLinkCreateUnidirectionalUnauthenticated(s *state.State, r *http.Request, req api.ClusterLinksPost, requestor *api.EventLifecycleRequestor) response.Response {
+	// Check if the caller has permission to create cluster links.
+	err := s.Authorizer.CheckPermission(r.Context(), entity.ServerURL(), auth.EntitlementCanCreateClusterLinks)
+	if err != nil {
+		return response.SmartError(err)
+	}
+
+	if req.ClusterCertificate == "" {
+		return response.BadRequest(errors.New("Cluster certificate required"))
+	}
+
+	block, _ := pem.Decode([]byte(req.ClusterCertificate))
+	if block == nil {
+		return response.BadRequest(errors.New("Failed decoding cluster certificate"))
+	}
+
+	remoteCert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return response.BadRequest(fmt.Errorf("Failed parsing cluster certificate: %w", err))
+	}
+
+	fingerprint := shared.CertFingerprint(remoteCert)
+
+	// Verify the remote address presents the expected certificate.
+	_, _, err = cluster.CheckClusterLinkCertificate(r.Context(), []string{req.RemoteAddress}, fingerprint, version.UserAgent)
+	if err != nil {
+		return response.BadRequest(fmt.Errorf("Failed validating cluster certificate: %w", err))
+	}
+
+	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
+		clusterLinkID, err := dbCluster.CreateClusterLink(ctx, tx.Tx(), dbCluster.ClusterLinkRow{
+			IdentityID:  nil,
+			Name:        req.Name,
+			Description: req.Description,
+			Type:        dbCluster.ClusterLinkType(api.ClusterLinkTypeUnidirectionalUnauthenticated),
+		})
+		if err != nil {
+			return fmt.Errorf("Failed creating cluster link %q: %w", req.Name, err)
+		}
+
+		if req.Config == nil {
+			req.Config = map[string]string{}
+		}
+
+		err = clusterLinkValidateConfig(req.Config)
+		if err != nil {
+			return err
+		}
+
+		req.Config["volatile.addresses"] = req.RemoteAddress
+		err = dbCluster.CreateClusterLinkConfig(ctx, tx.Tx(), clusterLinkID, req.Config)
+		if err != nil {
+			return err
+		}
+
+		return dbCluster.SetClusterLinkCertificate(ctx, tx.Tx(), clusterLinkID, fingerprint, req.ClusterCertificate)
+	})
+	if err != nil {
+		return response.SmartError(err)
+	}
+
+	s.Events.SendLifecycle(api.ProjectDefaultName, lifecycle.ClusterLinkCreated.Event(req.Name, requestor, nil))
+
+	return response.EmptySyncResponse
 }

--- a/lxd/cluster/cluster_link.go
+++ b/lxd/cluster/cluster_link.go
@@ -172,6 +172,17 @@ func LoadClusterLinkAndCert(ctx context.Context, tx *sql.Tx, name string) (id in
 	return dbLink.ID, clusterLink, cert, nil
 }
 
+// GetUnauthenticatedClusterLinkConnectionArgs builds connection args for unauthenticated unidirectional cluster links.
+// No client certificate is presented; only the server certificate is pinned.
+func GetUnauthenticatedClusterLinkConnectionArgs(targetCert *x509.Certificate) *lxd.ConnectionArgs {
+	targetCertStr := string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: targetCert.Raw}))
+
+	return &lxd.ConnectionArgs{
+		TLSServerCert: targetCertStr,
+		UserAgent:     version.UserAgent,
+	}
+}
+
 // ConnectCluster connects to a linked cluster using the provided connection args, trying each address until one succeeds.
 func ConnectCluster(ctx context.Context, clusterLink api.ClusterLink, args *lxd.ConnectionArgs) (lxd.InstanceServer, error) {
 	addresses := shared.SplitNTrimSpace(clusterLink.Config["volatile.addresses"], ",", -1, false)
@@ -214,8 +225,13 @@ func RefreshClusterLinkVolatileAddresses(ctx context.Context, s *state.State, na
 		return nil
 	}
 
-	clusterCert := s.Endpoints.NetworkCert()
-	args := GetClusterLinkConnectionArgs(clusterCert, targetCert)
+	var args *lxd.ConnectionArgs
+	if clusterLink.Type == api.ClusterLinkTypeUnidirectionalUnauthenticated {
+		args = GetUnauthenticatedClusterLinkConnectionArgs(targetCert)
+	} else {
+		clusterCert := s.Endpoints.NetworkCert()
+		args = GetClusterLinkConnectionArgs(clusterCert, targetCert)
+	}
 
 	targetClient, err := ConnectCluster(ctx, *clusterLink, args)
 	if err != nil {

--- a/lxd/db/cluster/cluster_links.go
+++ b/lxd/db/cluster/cluster_links.go
@@ -20,8 +20,9 @@ import (
 type ClusterLinkType string
 
 const (
-	clusterLinkTypeBidirectional  int64 = 0
-	clusterLinkTypeUnidirectional int64 = 1
+	clusterLinkTypeBidirectional                 int64 = 0
+	clusterLinkTypeUnidirectional                int64 = 1
+	clusterLinkTypeUnidirectionalUnauthenticated int64 = 2
 )
 
 // ClusterLinkRow represents a single row of the cluster_links table.
@@ -46,6 +47,8 @@ func (c *ClusterLinkType) ScanInteger(clusterLinkTypeCode int64) error {
 		*c = api.ClusterLinkTypeBidirectional
 	case clusterLinkTypeUnidirectional:
 		*c = api.ClusterLinkTypeUnidirectional
+	case clusterLinkTypeUnidirectionalUnauthenticated:
+		*c = api.ClusterLinkTypeUnidirectionalUnauthenticated
 	default:
 		return fmt.Errorf("Unknown cluster link type %d", clusterLinkTypeCode)
 	}
@@ -65,6 +68,8 @@ func (c ClusterLinkType) Value() (driver.Value, error) {
 		return clusterLinkTypeBidirectional, nil
 	case api.ClusterLinkTypeUnidirectional:
 		return clusterLinkTypeUnidirectional, nil
+	case api.ClusterLinkTypeUnidirectionalUnauthenticated:
+		return clusterLinkTypeUnidirectionalUnauthenticated, nil
 	}
 
 	return nil, fmt.Errorf("Invalid cluster link type %q", c)

--- a/shared/api/cluster.go
+++ b/shared/api/cluster.go
@@ -14,6 +14,11 @@ const (
 	//
 	// API extension: cluster_links_unidirectional.
 	ClusterLinkTypeUnidirectional = "unidirectional"
+
+	// ClusterLinkTypeUnidirectionalUnauthenticated indicates that only the local cluster can use the link and no client certificate is presented.
+	//
+	// API extension: cluster_links_unidirectional.
+	ClusterLinkTypeUnidirectionalUnauthenticated = "unidirectional-unauthenticated"
 )
 
 // Cluster represents high-level information about a LXD cluster.
@@ -496,6 +501,25 @@ type ClusterLinksPost struct {
 	// The certificate (X509 PEM encoded) for the linked cluster. This is included in server-side POST requests to activate the pending cluster link on the linked cluster that generated the trust token.
 	// Example: X509 PEM certificate
 	ClusterCertificate string `json:"cluster_certificate" yaml:"cluster_certificate"`
+
+	// RemoteAddress is the address of the remote cluster, used for unauthenticated unidirectional links.
+	// Example: 10.0.0.1:8443
+	RemoteAddress string `json:"remote_address,omitempty" yaml:"remote_address,omitempty"`
+}
+
+// ClusterLinkCertificate represents a remote cluster certificate fetched for user verification.
+//
+// swagger:model
+//
+// API extension: cluster_links_unidirectional.
+type ClusterLinkCertificate struct {
+	// SHA-256 fingerprint of the certificate.
+	// Example: a1b2c3d4...
+	Fingerprint string `json:"fingerprint" yaml:"fingerprint"`
+
+	// PEM-encoded X.509 certificate.
+	// Example: -----BEGIN CERTIFICATE-----\n...
+	Certificate string `json:"certificate" yaml:"certificate"`
 }
 
 // ClusterLinkPost represents the fields available for renaming a cluster link.

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -6061,13 +6061,26 @@ test_clustering_link_unidirectional() {
   LXD_DIR="${LXD_ONE_DIR}" lxc cluster enable node1
   LXD_DIR="${LXD_TWO_DIR}" lxc cluster enable node2
 
+  LXD_ONE_ADDR="$(LXD_DIR="${LXD_ONE_DIR}" lxc config get core.https_address)"
+  LXD_TWO_ADDR="$(LXD_DIR="${LXD_TWO_DIR}" lxc config get core.https_address)"
+
   sub_test "Check CLI validation for unidirectional flags"
+
+  # --unidirectional and --unauthenticated are mutually exclusive.
+  [ "$(CLIENT_DEBUG="" SHELL_TRACING="" LXD_DIR="${LXD_ONE_DIR}" lxc cluster link create foo --unidirectional --unauthenticated 2>&1)" = 'Error: --unidirectional and --unauthenticated cannot be used together' ]
 
   # --unidirectional without --token must fail.
   [ "$(CLIENT_DEBUG="" SHELL_TRACING="" LXD_DIR="${LXD_ONE_DIR}" lxc cluster link create foo --unidirectional 2>&1)" = 'Error: --unidirectional requires --token' ]
 
-  # --auth-group cannot be used with unidirectional links.
+  # --unauthenticated without --remote-address must fail.
+  [ "$(CLIENT_DEBUG="" SHELL_TRACING="" LXD_DIR="${LXD_ONE_DIR}" lxc cluster link create foo --unauthenticated 2>&1)" = 'Error: --unauthenticated requires --remote-address' ]
+
+  # --remote-address without --unauthenticated must fail.
+  [ "$(CLIENT_DEBUG="" SHELL_TRACING="" LXD_DIR="${LXD_ONE_DIR}" lxc cluster link create foo --remote-address "${LXD_TWO_ADDR}" 2>&1)" = 'Error: --remote-address requires --unauthenticated' ]
+
+  # --auth-group cannot be used with unidirectional or unauthenticated links.
   [ "$(CLIENT_DEBUG="" SHELL_TRACING="" LXD_DIR="${LXD_ONE_DIR}" lxc cluster link create foo --unidirectional --token fake --auth-group mygroup 2>&1)" = 'Error: --auth-group cannot be used with unidirectional cluster links' ]
+  [ "$(CLIENT_DEBUG="" SHELL_TRACING="" LXD_DIR="${LXD_ONE_DIR}" lxc cluster link create foo --unauthenticated --remote-address "${LXD_TWO_ADDR}" --auth-group mygroup 2>&1)" = 'Error: --auth-group cannot be used with unidirectional cluster links' ]
 
   sub_test "Check authenticated unidirectional link creation"
 
@@ -6134,6 +6147,75 @@ test_clustering_link_unidirectional() {
 
   if LXD_DIR="${LXD_TWO_DIR}" lxc auth identity list --format csv | grep -F 'Cluster link certificate'; then
     echo "ERROR: cluster link certificate unexpectedly found on B after deletion" >&2
+    exit 1
+  fi
+
+  sub_test "Check pending creation rejected for unauthenticated unidirectional type"
+
+  # Directly calling the API with type=unidirectional-unauthenticated and a name but no
+  # remote_address must be rejected; pending creation is not valid for this type.
+  resp="$(LXD_DIR="${LXD_ONE_DIR}" lxc query --request POST /1.0/cluster/links --data '{"name":"bad-link","type":"unidirectional-unauthenticated"}' 2>&1)" || true
+  echo "${resp}" | grep -qF 'Unauthenticated unidirectional cluster links require remote_address and cluster_certificate'
+
+  # Ensure no link was created.
+  if LXD_DIR="${LXD_ONE_DIR}" lxc cluster link list --format csv | grep -F 'bad-link'; then
+    echo "ERROR: cluster link 'bad-link' unexpectedly created for pending unauthenticated request" >&2
+    exit 1
+  fi
+
+  sub_test "Check certificate endpoint returns fingerprint and certificate"
+
+  cert_resp="$(LXD_DIR="${LXD_ONE_DIR}" lxc query "/1.0/cluster/links/certificate?address=${LXD_TWO_ADDR}")"
+  echo "${cert_resp}" | jq --exit-status '.fingerprint != null and .fingerprint != ""' > /dev/null
+  echo "${cert_resp}" | jq --exit-status '.certificate != null and .certificate != ""' > /dev/null
+
+  sub_test "Check unauthenticated unidirectional link: certificate rejection"
+
+  # Responding 'n' to the fingerprint prompt must abort link creation.
+  # Use 2>&1 >/dev/null to capture only stderr (the error message), discarding the interactive prompt on stdout.
+  [ "$(printf 'n\n' | CLIENT_DEBUG="" SHELL_TRACING="" LXD_DIR="${LXD_ONE_DIR}" lxc cluster link create lxd_two --unauthenticated --remote-address "${LXD_TWO_ADDR}" 2>&1 >/dev/null)" = 'Error: Remote cluster certificate NACKed by user' ]
+  if LXD_DIR="${LXD_ONE_DIR}" lxc cluster link list --format csv | grep -F 'lxd_two'; then
+    echo "ERROR: cluster link 'lxd_two' unexpectedly found on A after certificate rejection" >&2
+    exit 1
+  fi
+
+  sub_test "Check unauthenticated unidirectional link creation"
+
+  # Responding 'y' to the fingerprint prompt creates the link on A only.
+  printf 'y\n' | LXD_DIR="${LXD_ONE_DIR}" lxc cluster link create lxd_two --unauthenticated --remote-address "${LXD_TWO_ADDR}"
+
+  LXD_DIR="${LXD_ONE_DIR}" lxc cluster link list --format csv | grep -F 'lxd_two'
+  LXD_DIR="${LXD_ONE_DIR}" lxc cluster link show lxd_two | grep -F 'type: unidirectional-unauthenticated'
+
+  # B must have no knowledge of this link.
+  if LXD_DIR="${LXD_TWO_DIR}" lxc cluster link list --format csv | grep -F 'lxd_one'; then
+    echo "ERROR: cluster link 'lxd_one' unexpectedly found on B" >&2
+    exit 1
+  fi
+
+  if LXD_DIR="${LXD_TWO_DIR}" lxc auth identity list --format csv | grep -F 'Cluster link certificate'; then
+    echo "ERROR: cluster link certificate unexpectedly found on B" >&2
+    exit 1
+  fi
+
+  # No identity should exist on A either.
+  if LXD_DIR="${LXD_ONE_DIR}" lxc auth identity list --format csv | grep -F 'Cluster link certificate'; then
+    echo "ERROR: cluster link certificate unexpectedly found on A" >&2
+    exit 1
+  fi
+
+  sub_test "Check unauthenticated unidirectional link: link state reachable"
+
+  # Unauthenticated links present no client certificate, so the remote sees an untrusted connection.
+  # The expected state is UNAUTHENTICATED (reachable but not trusted), not ACTIVE.
+  LXD_DIR="${LXD_ONE_DIR}" lxc cluster link info lxd_two | grep -F 'UNAUTHENTICATED'
+
+  sub_test "Check unauthenticated unidirectional link deletion"
+
+  # Deleting the link on A should succeed without any identity cleanup.
+  LXD_DIR="${LXD_ONE_DIR}" lxc cluster link delete lxd_two
+  if LXD_DIR="${LXD_ONE_DIR}" lxc cluster link list --format csv | grep -F 'lxd_two'; then
+    echo "ERROR: cluster link 'lxd_two' unexpectedly found on A after deletion" >&2
     exit 1
   fi
 


### PR DESCRIPTION
Adds unauthenticated unidirectional cluster link support.

Part 2 of a stacked PR set. Depends on #2.